### PR TITLE
[add] Add a "minRadius" parameter to the class ZoSignalBorder

### DIFF
--- a/lib/painter/zo_signal_painter.dart
+++ b/lib/painter/zo_signal_painter.dart
@@ -4,11 +4,13 @@ class ZoSignalPainter extends CustomPainter {
   final Animation<double> progress;
   final List<Color> ringColors;
   final double borderRadius;
+  final double minRadius;
   final double maxRadius;
 
   ZoSignalPainter(
       {required this.progress,
       required this.ringColors,
+      required this.minRadius,
       required this.maxRadius,
       this.borderRadius = 0})
       : super(repaint: progress);
@@ -19,7 +21,7 @@ class ZoSignalPainter extends CustomPainter {
 
     for (int i = 0; i < ringColors.length; i++) {
       double rippleProgress = (progress.value + (i / ringColors.length)) % 1.0;
-      double radius = rippleProgress * maxRadius;
+      double radius = minRadius + (maxRadius - minRadius) * rippleProgress;
 
       final paint = Paint()
         ..color = ringColors[i].withValues(alpha: 1.0 - rippleProgress)

--- a/lib/widget/zo_signal_border.dart
+++ b/lib/widget/zo_signal_border.dart
@@ -6,6 +6,7 @@ class ZoSignalBorder extends StatefulWidget {
   final Widget child;
   final Duration animationDuration;
   final double borderRadius;
+  final double minRadius;
   final double maxRadius;
   final Curve animationCurve;
 
@@ -13,6 +14,7 @@ class ZoSignalBorder extends StatefulWidget {
       {super.key,
       required this.ringColors,
       required this.child,
+      this.minRadius = 0,
       this.maxRadius = 180,
       this.animationCurve = Curves.linear,
       this.animationDuration = const Duration(seconds: 3),
@@ -49,6 +51,7 @@ class _ZoSignalBorderState extends State<ZoSignalBorder>
   Widget build(BuildContext context) {
     return CustomPaint(
         painter: ZoSignalPainter(
+          minRadius: widget.minRadius,
           maxRadius: widget.maxRadius,
           borderRadius: widget.borderRadius,
           progress: _curvedAnimation,


### PR DESCRIPTION
This allows to fix the starting radius of the ZoSignalBorder animation. Default to 0, the value is represented in pixel.
There is no check that minRadius > maxRadius : in fact, this gives a particular "inverted" animation that is appreciated :)